### PR TITLE
Add a tabindex to potentially-overflowing code blocks

### DIFF
--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -22,7 +22,7 @@ module.exports = function (content, language, highlightNumbers, options = {}) {
     let classString = options.className ? " " + options.className : "";
 
     return (
-        `<pre class="language-${language}${classString}"><code class="language-${language}${classString}">` +
+        `<pre class="language-${language}${classString}" tabindex="0"><code class="language-${language}${classString}">` +
         lines.join("<br>") +
         "</code></pre>"
     );

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -34,7 +34,7 @@ module.exports = function (options = {}) {
 
         let classString = options.className ? " " + options.className : "";
 
-        return `<pre class="language-${language}${classString}"><code class="language-${language}${classString}">${lines.join(
+        return `<pre class="language-${language}${classString}" tabindex="0"><code class="language-${language}${classString}">${lines.join(
             "<br>"
         )}</code></pre>`;
     };


### PR DESCRIPTION
Since our code blocks overflow with scrollbars, it's important that they're focusable. Adding `tabindex="0"` allows for keyboard focus and scrolling when things overflow. https://dequeuniversity.com/rules/axe/4.3/scrollable-region-focusable?application=AxeChrome

This adds it to our plugin so the documentation is accessible.