### PR TITLE
Add getAttributes to allow for custom attributes

### DIFF
--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -1,8 +1,12 @@
 const hljs = require("highlight.js");
 const HighlightLinesGroup = require("./HighlightLinesGroup");
+const getAttributes = require("./getAttributes");
 
 module.exports = function (content, language, highlightNumbers, options = {}) {
-    let highlightedContent;
+    const preAttributes = getAttributes(options.preAttributes);
+    const codeAttributes = getAttributes(options.codeAttributes);
+  
+      let highlightedContent;
     if (language === "text") {
         highlightedContent = content.trim();
     } else {
@@ -22,7 +26,7 @@ module.exports = function (content, language, highlightNumbers, options = {}) {
     let classString = options.className ? " " + options.className : "";
 
     return (
-        `<pre class="language-${language}${classString}"><code class="language-${language}${classString}">` +
+        `<pre class="language-${language}${classString}"${preAttributes}><code class="language-${language}${classString}"${codeAttributes}>` +
         lines.join("<br>") +
         "</code></pre>"
     );

--- a/src/HighlightPairedShortcode.js
+++ b/src/HighlightPairedShortcode.js
@@ -5,8 +5,8 @@ const getAttributes = require("./getAttributes");
 module.exports = function (content, language, highlightNumbers, options = {}) {
     const preAttributes = getAttributes(options.preAttributes);
     const codeAttributes = getAttributes(options.codeAttributes);
-  
-      let highlightedContent;
+
+    let highlightedContent;
     if (language === "text") {
         highlightedContent = content.trim();
     } else {

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -1,0 +1,39 @@
+function attributeEntryToString([key, value]) {
+  if (typeof value !== "string" && typeof value !== "number")
+    throw new Error(
+      `Attribute "${key}" must have a value of type string or number not "${typeof value}".`
+    );
+
+  return `${key}="${value}"`;
+}
+
+/**
+ * ## Usage
+ * The function `getAttributes` is used to convert an object, `attributes`, with HTML attributes as keys and the values as the corresponding HTML attribute's values.
+ * If it is falsey, an empty string will be returned.
+ *
+ * ```js
+  getAttributes({
+    tabindex: 0,
+    'data-language': 'JavaScript',
+    'data-otherStuff': 'value'
+  }) // => ' tabindex="0" data-language="JavaScript" data-otherStuff="value"'
+  ```
+ *
+ * @param {{[s: string]: string | number}} attributes An object with key-value pairs that represent attributes.
+ * @returns {string} A string containing the above HTML attributes preceded by a single space.
+ */
+function getAttributes(attributes) {
+  if (!attributes) {
+    return "";
+  } else if (typeof attributes === "object") {
+    const formattedAttributes = Object.entries(attributes).map(
+      attributeEntryToString
+    );
+    return formattedAttributes.length ? ` ${formattedAttributes.join(" ")}` : "";
+  } else if (typeof attributes === "string") {
+    throw new Error("Syntax highlighter plugin custom attributes on <pre> and <code> must be an object. Received: " + JSON.stringify(attributes));
+  }
+}
+
+module.exports = getAttributes;

--- a/src/markdownSyntaxHighlightOptions.js
+++ b/src/markdownSyntaxHighlightOptions.js
@@ -1,7 +1,11 @@
 const hljs = require("highlight.js");
 const HighlightLinesGroup = require("./HighlightLinesGroup");
+const getAttributes = require("./getAttributes");
 
 module.exports = function (options = {}) {
+    const preAttributes = getAttributes(options.preAttributes);
+    const codeAttributes = getAttributes(options.codeAttributes);
+
     return function (str, language) {
         if (!language) {
             // empty string means defer to the upstream escaping code built into markdown lib.
@@ -34,7 +38,7 @@ module.exports = function (options = {}) {
 
         let classString = options.className ? " " + options.className : "";
 
-        return `<pre class="language-${language}${classString}"><code class="language-${language}${classString}">${lines.join(
+        return `<pre class="language-${language}${classString}"${preAttributes}><code class="language-${language}${classString}"${codeAttributes}>${lines.join(
             "<br>"
         )}</code></pre>`;
     };


### PR DESCRIPTION
Lifted from https://github.com/11ty/eleventy-plugin-syntaxhighlight/blob/master/src/getAttributes.js and associated.

**The _what_**: This PR will allow us to add arbitrary attributes to the `<pre>` and `<code>` elements.

**The _why_**: While working on https://github.com/StackExchange/Stacks/issues/829, I realized I couldn't add a `data-` attribute to the `<code>` element in the Stacks docs. I'm not positive I'll need it for https://github.com/StackExchange/Stacks/issues/829, but I went through the trouble, so here we are.

P.S. I could've also sworn I saw an issue requesting a `tabindex` be added to `<code>` or `<pre>` elements for some reason, but I can't seem to find it. Nevertheless, this PR would enable that too.