### PR TITLE
Add filter version of 'highlight'

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,19 @@ module.exports = {
             options
         );
 
+        // A universal filter for all
+        // {{ some_variable | highlight: "html 0 2-3" }}
+        eleventyConfig.addFilter("highlight", (content, arguments) => {
+            const [language, ...highlightNumbers] = arguments.split(" ");
+
+            return HighlightPairedShortcode(
+                content,
+                language,
+                highlightNumbers.join(" "),
+                options,
+            );
+        });
+
         if (hasTemplateFormat(options.templateFormats, "liquid")) {
             eleventyConfig.addLiquidTag("highlight", (liquidEngine) => {
                 // {% highlight js 0 2 %}

--- a/demo/test-liquid.liquid
+++ b/demo/test-liquid.liquid
@@ -29,5 +29,23 @@ let multilineString = `
   this is the last line
 `;
 {% endhighlight %}
+
+{% capture capture_1 %}
+let multilineString = `
+  this is the first line
+  this is the middle line
+  this is the last line
+`;
+{% endcapture %}
+{{ capture_1 | highlight: "js" }}
+
+{% capture capture_2 %}
+let multilineString = `
+  this is the first line
+  this is the middle line
+  this is the last line
+`;
+{% endcapture %}
+{{ capture_2 | highlight: "js 1,3" }}
     </body>
 </html>


### PR DESCRIPTION
Let's have the ability to feed captured content through a `highlight` filter since using the `{% highlight %}` tag treats anything inside of it as a string instead of parsing Liquid.

```liquid
{% capture sample_code %}
let multilineString = `
  this is the first line
  this is the middle line
  this is the last line
`;
{% endcapture %}
{{ sample_code | highlight: "js" }}
```